### PR TITLE
ZEN-29011: Rewrite DigMonitor to remove reference to Nagios GPL Plugins

### DIFF
--- a/ZenPacks/zenoss/DigMonitor/__init__.py
+++ b/ZenPacks/zenoss/DigMonitor/__init__.py
@@ -1,6 +1,11 @@
 
 import Globals
+import glob
+import platform
 import os.path
+
+from Products.ZenModel.ZenPack import ZenPackBase
+from Products.ZenUtils.Utils import zenPath
 
 import logging
 log = logging.getLogger("zen.DigMonitor")
@@ -19,3 +24,32 @@ def onCollectorInstalled(ob, event):
     code, output = ob.executeCommand('zenbincheck %s' % verifyBin, 'zenoss', needsZenHome=True)
     if code:
        	log.warn(errormsg.format(verifyBin, ob.hostname, zpFriendly))
+
+
+class ZenPack(ZenPackBase):
+
+    products = ('twisted',)
+    
+    def install(self, app):
+        self.patchProducts()
+        ZenPackBase.install(self, app)
+
+    def upgrade(self, app):
+        ZenPackBase.upgrade(self, app)
+        self.patchProducts()
+
+    def patchProducts(self):
+        for product in self.products:
+            relevant_patches = sorted(glob.glob(os.path.join(self.path('src'), product + '.all.patch[0-9]*')))
+            for patch in relevant_patches:
+                if os.path.isfile(patch):
+                    log.info("Patching %s with %s" % (product, patch))
+                    log.info(" patch -p0 -d %s -i %s" %
+                        (zenPath(), patch))
+                    #import pdb; pdb.set_trace()
+                    os.system("patch -p0 -d %s -i %s" % (
+                        zenPath(), patch))
+                else:
+                    log.warn("Patch file %s does not exist" % patch)
+                    log.warn("Skipping patch -p0 -d %s -i %s" %
+                        (zenPath(), patch))

--- a/ZenPacks/zenoss/DigMonitor/datasources/DigMonitorDataSource.py
+++ b/ZenPacks/zenoss/DigMonitor/datasources/DigMonitorDataSource.py
@@ -1,6 +1,6 @@
 ##############################################################################
 # 
-# Copyright (C) Zenoss, Inc. 2007, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
 # 
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -8,14 +8,45 @@
 ##############################################################################
 
 
-from AccessControl import ClassSecurityInfo, Permissions
+from distutils.util import strtobool
+import logging
+import re
+import time
 
 import Products.ZenModel.RRDDataSource as RRDDataSource
-from Products.ZenModel.ZenPackPersistence import ZenPackPersistence
-from Products.ZenUtils.ZenTales import talesCompile, getEngine
-from Products.ZenUtils.Utils import binPath
 
-class DigMonitorDataSource(ZenPackPersistence, RRDDataSource.RRDDataSource):
+from twisted.internet import defer
+from twisted.names import client, dns, error
+
+from Products.ZenEvents import ZenEventClasses
+
+from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
+    import PythonDataSource, PythonDataSourcePlugin
+
+log = logging.getLogger('zen.DigMonitor')
+
+RECORDS = {
+    'A':        {'id': 1,  'message': 'messageA'},
+    'AAAA':     {'id': 28, 'message': 'messageAaaa'},
+    'CNAME':    {'id': 5,  'message': 'messageCnameNsPtr'},
+    'MX':       {'id': 15, 'message': 'messageMx'},
+    'NAPTR':    {'id': 35, 'message': 'messageNaptr'},
+    'NS':       {'id': 2,  'message': 'messageCnameNsPtr'},
+    'PTR':      {'id': 12, 'message': 'messageCnameNsPtr'},
+    'SOA':      {'id': 6,  'message': 'messageSoa'},
+    'SRV':      {'id': 33, 'message': 'messageSrv'},
+    'TXT':      {'id': 16, 'message': 'messageTxt'},
+    'SSHFP':    {'id': 44, 'message': 'messageSshfp'},
+}
+
+
+class DnsException(Exception):
+    """
+    Dns Exception.
+    """
+
+
+class DigMonitorDataSource(PythonDataSource):
     
     ZENPACKID = 'ZenPacks.zenoss.DigMonitor'
     DIG_MONITOR = 'DigMonitor'
@@ -23,9 +54,12 @@ class DigMonitorDataSource(ZenPackPersistence, RRDDataSource.RRDDataSource):
     sourcetypes = (DIG_MONITOR,)
     sourcetype = DIG_MONITOR
 
+    plugin_classname = (
+        ZENPACKID + '.datasources.DigMonitorDataSource.DigMonitorDataSourcePlugin')
+
     eventClass = '/Status/DNS'
     allRecordTypes = ['A', 'AAAA', 'CNAME', 'MX', 'NAPTR', 'NS',
-                      'PTR', 'SOA', 'SRV', 'SSHFP', 'TKEY', 'TXT']
+                      'PTR', 'SOA', 'SRV', 'TXT', 'SSHFP']
     
     dnsServer = '${dev/id}'
     port = 53
@@ -42,82 +76,275 @@ class DigMonitorDataSource(ZenPackPersistence, RRDDataSource.RRDDataSource):
         {'id':'timeout', 'type':'int', 'mode':'w'},
         {'id':'tcp', 'type':'boolean', 'mode':'w'},
         )
-        
-    _relations = RRDDataSource.RRDDataSource._relations + (
-        )
 
 
-    factory_type_information = ( 
-    { 
-        'immediate_view' : 'editDigMonitorDataSource',
-        'actions'        :
-        ( 
-            { 'id'            : 'edit',
-              'name'          : 'Data Source',
-              'action'        : 'editDigMonitorDataSource',
-              'permissions'   : ( Permissions.view, ),
-            },
-        )
-    },
-    )
+class DigMonitorDataSourcePlugin(PythonDataSourcePlugin):
 
-    security = ClassSecurityInfo()
+    @classmethod
+    def params(cls, datasource, context):
+        params = {}
 
+        params['dnsServer'] = datasource.talesEval(
+            datasource.dnsServer, context)
 
-    def __init__(self, id, title=None, buildRelations=True):
-        RRDDataSource.RRDDataSource.__init__(self, id, title, buildRelations)
-        #self.addDataPoints()
+        params['port'] = datasource.talesEval(
+            datasource.port, context)
 
+        params['recordName'] = datasource.talesEval(
+            datasource.recordName, context)
 
-    def getDescription(self):
-        if self.sourcetype == self.DIG_MONITOR:
-            ipAddress = getattr(self, 'ipAddress', '')
-            hostname = getattr(self, 'hostname', '')
-            description = ipAddress + hostname
+        params['recordType'] = datasource.talesEval(
+            datasource.recordType, context)
+
+        params['eventKey'] = datasource.talesEval(
+            datasource.eventKey, context)
+
+        params['component'] = datasource.talesEval(
+            datasource.component, context)
+
+        params['timeout'] = datasource.talesEval(
+            datasource.timeout, context)
+
+        params['useTCP'] = datasource.talesEval(
+            datasource.tcp, context)        
+
+        return params
+
+    def collect(self, config):
+        ds0 = config.datasources[0]
+
+        dnsServer = ds0.params['dnsServer']
+        port = ds0.params['port']
+
+        if dnsServer:
+            self.resolver = client.Resolver(servers=[(dnsServer, int(port))])
         else:
-            description = RRDDataSource.RRDDataSource.getDescription(self)
-        return description
+            self.resolver = client.Resolver('/etc/resolv.conf')
+        self._startTime = time.time()
+        
+        query = self.resolver.queryUDP
+        if strtobool(ds0.params.get('useTCP', 'False')):
+            query = self.resolver.queryTCP
 
+        d = query([dns.Query(ds0.params['recordName'],
+            RECORDS.get(ds0.params['recordType'])['id'])])
 
-    def useZenCommand(self):
-        return True
+        return d
 
+    def onSuccess(self, result, config):
+        respTime = time.time() - self._startTime
+        data = self.new_data()
+        perfData = {}
+        perfData['time'] = respTime
+        ds0 = config.datasources[0]
 
-    def getCommand(self, context):
-        parts = [binPath('check_dig')]
-        if self.dnsServer:
-            parts.append('-H %s' % self.dnsServer)
-        if self.port:
-            parts.append('-p %d' % self.port)
-        if self.tcp:
-            parts.append('-A +tcp')
-        if self.recordName:
-            parts.append('-l %s' % self.recordName)
-        if self.recordType:
-            parts.append('-T %s' % self.recordType)
-        if self.timeout:
-            parts.append('-t %d' % self.timeout)
+        if not result.answers:
+            message = ("DNS CRITICAL - {:.3f} seconds response time "
+                "(No ANSWER SECTION found)".format(
+                respTime))
+            raise DnsException(message)
+        else:
+            response = result.answers[0]        
+        
+        message = getattr(self,
+            RECORDS.get(ds0.params['recordType'])['message'])(
+            response, respTime)
+        import pdb; pdb.set_trace()
+        log.debug('{} {}'.format(config.id, message))
 
-        cmd = ' '.join(parts)
-        cmd = RRDDataSource.RRDDataSource.getCommand(self, context, cmd)
-        return cmd
+        for dp in ds0.points:
+            if dp.id in perfData:
+                data['values'][None][dp.id] = perfData[dp.id]
 
+        eventKey = ds0.eventKey  or 'DnsMonitorWarning'
 
-    def checkCommandPrefix(self, context, cmd):
-        return cmd
+        data['events'].append({
+            'eventClassKey': 'DigMonitorSuccess',
+            'eventKey': eventKey,
+            'summary': message,
+            'message': message,
+            'device': config.id,
+            'eventClass': ds0.eventClass,
+            'severity': ZenEventClasses.Clear
+        })
 
+        return data
 
-    def addDataPoints(self):
-        if not hasattr(self.datapoints, 'time'):
-            self.manage_addRRDDataPoint('time')
+    def onError(self, result, config):
+        import pdb; pdb.set_trace()
+        respTime = time.time() - self._startTime
+        DNSNameError = False
+        data = self.new_data()
+        perfData = {}
+        ds0 = config.datasources[0]
+        if hasattr(result.value, 'subFailure'):
+            if isinstance(result.value.subFailure.value, error.DNSNameError):
+                message = ("DNS WARNING - "
+                    "Server: {} - Domain name '{}' "
+                    "not found".format(self.resolver.pickServer()[0],
+                        ds0.params['recordName']))
+                DNSNameError = True
+            elif isinstance(result.value.subFailure.value, defer.TimeoutError):
+                message = ("DNS WARNING - "
+                    "Server: {}, Port: {} - "
+                    "TimeoutError".format(
+                        self.resolver.pickServer()[0],
+                        self.resolver.pickServer()[1]))
+            severity = ds0.severity
+        else:
+            message = '{}'.format(result.getErrorMessage())
+            severity = ZenEventClasses.Error
 
+        if not isinstance(result.value, DnsException) and not DNSNameError:
+            respTime = None
+        
+        log.error('{} {}'.format(config.id, message))
 
-    def zmanage_editProperties(self, REQUEST=None):
-        '''validation, etc'''
-        if REQUEST:
-            # ensure default datapoint didn't go away
-            self.addDataPoints()
-            # and eventClass
-            if not REQUEST.form.get('eventClass', None):
-                REQUEST.form['eventClass'] = self.__class__.eventClass
-        return RRDDataSource.RRDDataSource.zmanage_editProperties(self, REQUEST)
+        if respTime:
+            perfData['time'] = respTime
+            for dp in ds0.points:
+                if dp.id in perfData:
+                    data['values'][None][dp.id] = perfData[dp.id]
+
+        eventKey = ds0.eventKey or 'DigMonitorWarning'
+        data['events'].append({
+            'eventClassKey': 'DigMonitorWarning',
+            'eventKey': eventKey,
+            'summary': message,
+            'message': message,
+            'device': config.id,
+            'severity': severity,
+            'eventClass': ds0.eventClass
+        })
+
+        return data
+
+    def _getCommonValues(self, response, respTime):
+        s = response.__str__()
+        values = [respTime]
+        for x in ('name', 'ttl', 'class', 'type',):
+            pattern = r'(?<={}=)[^\s]+'.format(x)
+            if x == 'ttl':
+                pattern = r'(?<={}=)[^\s^s]+'.format(x)
+            try:
+                values.append(
+                    re.search(re.compile(pattern), s).group())
+            except AttributeError:
+                values.append(None)
+                
+        return values       
+
+    def messageA(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        values.append(response.payload.dottedQuad())
+
+        return ("DNS OK - {:.3f} seconds response time "
+            "({}.  {} {} {} {})".format(*values))
+
+    def messageAaaa(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        values.append(response.payload._address)
+
+        return ("DNS OK - {:.3f} seconds response time "
+            "({}.  {} {} {} {})".format(*values))
+
+    def messageCnameNsPtr(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        s = response.payload.__str__()
+        try:
+            name = re.search(re.compile(r'(?<=name=)[^\s]+'), s).group()
+        except AttributeError:
+            name = None        
+        values.append(name)
+
+        return ("DNS OK - {:.3f} seconds response time "
+            "({}. {} {} {} {}.)".format(*values))
+
+    def messageMx(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        s = response.payload.__str__()
+        try:
+            mxname = re.search(re.compile(r'(?<=name=)[^\s]+'), s).group()
+        except AttributeError:
+            mxname = None
+        values.extend((response.payload.preference, mxname))
+
+        return ("DNS OK - {:.3f} seconds response time "
+           "({}.  {} {} {} {} {})".format(*values))
+
+    def messageNaptr(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        s = response.payload.__str__()
+        for x in ('order', 'preference',):
+            pattern = r'(?<={}=)[^\s]+'.format(x)
+            try:
+                values.append(
+                    re.search(re.compile(pattern), s).group())
+            except AttributeError:
+                values.append(None)
+        message = ("DNS OK - {:.3f} seconds response time "
+            "({}. {} {} {} {} {}".format(*values))
+        for x in ('flags', 'service', 'regexp', 'replacement',):
+            pattern = r'(?<={}=)[^\s]+'.format(x)
+            try:
+                value = re.search(re.compile(pattern), s).group()
+                message = message + ' "' + value + '"'
+            except AttributeError:
+                message+=" "
+        message += ".)"
+
+        return message
+
+    def messageSoa(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        s = response.payload.__str__()
+        for x in ('mname', 'rname', 'serial', 'refresh',
+            'retry', 'expire', 'minimum',):
+            pattern = r'(?<={}=)[^\s]+'.format(x)
+            try:
+                values.append(
+                    re.search(re.compile(pattern), s).group())
+            except AttributeError:
+                values.append(None)
+
+        return ("DNS OK - {:.3f} seconds response time "
+            "({}.  {} {} {} {}. {}. {} {} {} {} {})".format(*values))
+
+    def messageSrv(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        s = response.payload.__str__()
+        for x in ('priority', 'weight', 'port', 'target',):
+            pattern = r'(?<={}=)[^\s]+'.format(x)
+            try:
+                values.append(
+                    re.search(re.compile(pattern), s).group())
+            except AttributeError:
+                values.append(None)
+
+        return ("DNS OK - {:.3f} seconds response time "
+            "({}.  {} {} {} {} {} {} {}.)".format(*values))
+
+    def messageTxt(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        message = ("DNS OK - {:.3f} seconds response time "
+            "({}.  {} {} {} ".format(*values))
+        for x in response.payload.data:
+            message = message + '"' + x + '"'
+        message += ")"
+
+        return message
+
+    def messageSshfp(self, response, respTime):
+        values = self._getCommonValues(response, respTime)
+        st = response.payload.__str__()
+        for x in ('algorithm', 'fp_type', 'fingerprint',):
+            pattern = r'(?<={}=)[^\s]+'.format(x)
+            try:
+                values.append(
+                    re.search(re.compile(pattern), st).group())
+            except AttributeError:
+                values.append(None)
+        if len(values[-1]) == 64:
+            values[-1] = ' '.join((values[-1][:-8], values[-1][-8:]))
+        return ("DNS OK - {:.3f} seconds response time "
+            "({}. {} {} {} {} {} {})".format(*values))

--- a/ZenPacks/zenoss/DigMonitor/src/twisted.all.patch01
+++ b/ZenPacks/zenoss/DigMonitor/src/twisted.all.patch01
@@ -1,0 +1,68 @@
+--- ./lib/python2.7/site-packages/twisted/names/dns.py
++++ ./lib/python2.7/site-packages/twisted/names/dns.py
+@@ -17,7 +17,7 @@
+     'A', 'A6', 'AAAA', 'AFSDB', 'CNAME', 'DNAME', 'HINFO',
+     'MAILA', 'MAILB', 'MB', 'MD', 'MF', 'MG', 'MINFO', 'MR', 'MX',
+     'NAPTR', 'NS', 'NULL', 'OPT', 'PTR', 'RP', 'SOA', 'SPF', 'SRV', 'TXT',
+-    'WKS',
++    'WKS', 'SSHFP',
+ 
+     'ANY', 'CH', 'CS', 'HS', 'IN',
+ 
+@@ -30,6 +30,7 @@
+     'Record_MG', 'Record_MINFO', 'Record_MR', 'Record_MX', 'Record_NAPTR',
+     'Record_NS', 'Record_NULL', 'Record_PTR', 'Record_RP', 'Record_SOA',
+     'Record_SPF', 'Record_SRV', 'Record_TXT', 'Record_WKS', 'UnknownRecord',
++    'Record_SSHFP',
+ 
+     'QUERY_CLASSES', 'QUERY_TYPES', 'REV_CLASSES', 'REV_TYPES', 'EXT_QUERIES',
+ 
+@@ -119,6 +120,7 @@
+ A6 = 38
+ DNAME = 39
+ OPT = 41
++SSHFP = 44
+ SPF = 99
+ 
+ QUERY_TYPES = {
+@@ -149,9 +151,38 @@
+     A6: 'A6',
+     DNAME: 'DNAME',
+     OPT: 'OPT',
+-    SPF: 'SPF'
++    SPF: 'SPF',
++    SSHFP: 'SSHFP',
+ }
+ 
++class Record_SSHFP(tputil.FancyEqMixin, tputil.FancyStrMixin):
++
++    TYPE = SSHFP
++
++    fancybasename = 'SSHFP'
++    compareAttributes = ('algorithm', 'fp_type', 'fingerprint', 'ttl')
++    showAttributes = ('algorithm',
++                      'fp_type',
++                      ('fingerprint', 'fingerprint', '%s'),
++                      'ttl')
++
++    def __init__(self, algorithm=0, fp_type=0, fingerprint='', ttl=None):
++        self.algorithm = int(algorithm)
++        self.fp_type = int(fp_type)
++        self.fingerprint = fingerprint
++        self.ttl = str2time(ttl)
++
++    def decode(self, strio, length = None):
++        r = struct.unpack('!BB', readPrecisely(strio, struct.calcsize('!BB')))
++        self.algorithm, self.fp_type = r
++        import codecs
++        if self.fp_type == 2:
++            self.fingerprint = codecs.encode(
++                readPrecisely(strio, struct.calcsize('!16H')), "hex").upper()            
++        else:
++            self.fingerprint = codecs.encode(
++                readPrecisely(strio, struct.calcsize('!10H')), "hex").upper()
++
+ IXFR, AXFR, MAILB, MAILA, ALL_RECORDS = range(251, 256)
+ 
+ # "Extended" queries (Hey, half of these are deprecated, good job)
+

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@
 # These variables are overwritten by Zenoss when the ZenPack is exported
 # or saved.  Do not modify them directly here.
 NAME = 'ZenPacks.zenoss.DigMonitor'
-VERSION = '1.1.2dev'
+VERSION = '2.0.0dev'
 AUTHOR = 'Zenoss'
 LICENSE = ''
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']
 PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.DigMonitor']
-INSTALL_REQUIRES = []
-COMPAT_ZENOSS_VERS = '>= 2.5.70'
+INSTALL_REQUIRES = ['ZenPacks.zenoss.PythonCollector']
+COMPAT_ZENOSS_VERS = '>= 4.2'
 PREV_ZENPACK_NAME = ''
 # STOP_REPLACEMENTS
 ################################


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29011

Old ZenPack fetches 12 types of dns records:

```
'A', 'AAAA', 'CNAME', 'MX', 'NAPTR', 'NS',
'PTR', 'SOA', 'SRV', 'SSHFP', 'TKEY', 'TXT'
```

Twisted allows to get only 10 of them, all except of `SSHFP` and `TKEY`.
To resolve this new record types should be added into twisted.

So far, `Record_SSHFP` is added.

`check_dig` returns messages in this format:

```
DNS OK - 0.049 seconds response time (motd.ch.  4121 IN SSHFP 1 1 598E08ADBFDEE83121BB4E646FA4873574243A81)|time=0.048639s;;;0.000000
```

old zenpack returns messages in this format:

```
DNS OK - 0.041 seconds response time (motd.ch.  3957 IN SSHFP 1 1 598E08ADBFDEE83121BB4E646FA4873574243A81)
```

https://github.com/twisted/twisted/blob/trunk/src/twisted/names/dns.py

Record_SSHFP test:
https://youtu.be/i0LaD_FFVvs